### PR TITLE
allow for namespaced mailers

### DIFF
--- a/lib/inline_styles_mailer.rb
+++ b/lib/inline_styles_mailer.rb
@@ -72,7 +72,8 @@ module InlineStylesMailer
         }.each do |template|
         # templates.each do |template|
           # e.g. template = app/views/user_mailer/welcome.html.erb
-          template_path = template.inspect.split("/").slice(-2, 2).join("/") # e.g. user_mailer/welcome.html.erb
+          # e.g. template = app/views/namespace/user_mailer/welcome.html.erb
+          template_path = template.inspect.split("views")[1][1..-1] # e.g. user_mailer/welcome.html.erb
           parts = template_path.split('.')
           handler = parts.pop.to_sym # e.g. erb
           extension = parts.pop.to_sym # e.g. html


### PR DESCRIPTION
This PR allows for namespaced mailers.

We ran into a small issue running this with a mounted engine in our Rails app. The `template_path` wasn't accounting for the namespace.

```ruby
template = /path/to/app/views/namespace/user_mailer/mailer_method.html.erb
template_path = template.inspect.split("/").slice(-2, 2).join("/")
# => user_mailer/mailer_method.html.erb
```

I updated the `template_path` variable, to split the `template` at "views", then keep the rest of the path that follows. This accounts to non-namespaced paths, namespaced paths, and paths that have multiple namespaces.

```ruby
template = /path/to/app/views/namespace/user_mailer/mailer_method.html.erb
template_path = template.inspect.split("views")[1][1..-1]
# => namespace/user_mailer/mailer_method.html.erb

template = /path/to/app/views/user_mailer/mailer_method.html.erb
template_path = template.inspect.split("views")[1][1..-1]
# => user_mailer/mailer_method.html.erb

template = /path/to/app/views/namespace/namespace_further/user_mailer/mailer_method.html.erb
template_path = template.inspect.split("views")[1][1..-1]
# => namespace/namespace_further/user_mailer/mailer_method.html.erb
```

Please let me know if anything else is needed! 

Again, much appreciation for maintaining this gem.