### PR TITLE
flatten_prefixes_array

### DIFF
--- a/lib/inline_styles_mailer.rb
+++ b/lib/inline_styles_mailer.rb
@@ -61,7 +61,7 @@ module InlineStylesMailer
         # Rails 3.1 takes an array, while Rails 3.0 takes a string.
         # See https://github.com/billhorsman/inline_styles_mailer/issues/1
         prefixes = options[:template_path] || self.class.name.underscore
-        prefixes = [prefixes] unless Rails.version =~ /^3\.0/
+        prefixes = [prefixes].flatten unless Rails.version =~ /^3\.0/
         templates = lookup_context.find_all(options[:template_name] || action_name, prefixes)
         options.reverse_merge!(:mime_version => "1.0", :charset => "UTF-8", :content_type => "text/plain", :parts_order => [ "text/plain", "text/enriched", "text/html"])
         templates.sort_by {|t|


### PR DESCRIPTION
```prefixes = options[:template_path]``` has already be an array when I use devise mailer
```
$ options
{:subject=>"subject",
 :to=>"test@example.com",
 :from=>"test" <noreply@example.com>",
 :reply_to=>"noreply@example.com",
 :template_path=>["users/mailer", "devise_mailer", "devise/mailer"],
 :template_name=>:confirmation_instructions}
```