### PR TITLE
Generate correct default css path for namespaced classes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 matrix:
   include:
-    - rvm: 2.0.0
+    - rvm: 2.0.0-p648
       gemfile: spec/Gemfile.rails-4.2
     - rvm: 2.1.8
       gemfile: spec/Gemfile.rails-4.2

--- a/lib/inline_styles_mailer.rb
+++ b/lib/inline_styles_mailer.rb
@@ -23,9 +23,8 @@ module InlineStylesMailer
     end
 
     def css_content
-      @stylesheets ||= ["_#{self.name.underscore}*"]
       @stylesheet_path ||= File.join("app", "assets", "stylesheets")
-      @css_content ||= @stylesheets.map {|stylesheet|
+      @css_content ||= stylesheets.map {|stylesheet|
         Dir[Rails.root.join(@stylesheet_path, "#{stylesheet}")].map {|file|
           case file
           when /\.scss$/
@@ -39,6 +38,14 @@ module InlineStylesMailer
         }.join("\n")
       }.compact.join("\n")
       @css_content
+    end
+
+    def stylesheets
+      return @stylesheets if defined? @stylesheets
+
+      path = self.name.underscore
+      modified_path = path.gsub(/\//, '/_')
+      @stylesheets = [modified_path == path ? "_#{path}*" :  "#{modified_path}*"]
     end
 
     def page

--- a/lib/inline_styles_mailer.rb
+++ b/lib/inline_styles_mailer.rb
@@ -41,11 +41,7 @@ module InlineStylesMailer
     end
 
     def stylesheets
-      return @stylesheets if defined? @stylesheets
-
-      path = self.name.underscore
-      modified_path = path.gsub(/\//, '/_')
-      @stylesheets = [modified_path == path ? "_#{path}*" :  "#{modified_path}*"]
+      @stylesheets ||= [self.name.underscore.sub(/^(.*\/)*(.*)$/, '\1_\2*')]
     end
 
     def page

--- a/spec/fixtures/assets/stylesheets/_foo_mailer.css.scss
+++ b/spec/fixtures/assets/stylesheets/_foo_mailer.css.scss
@@ -1,5 +1,5 @@
 body {
-  background: yellow;
+  background-color: yellow;
   p {
     color: red;
   }

--- a/spec/fixtures/assets/stylesheets/_override.css
+++ b/spec/fixtures/assets/stylesheets/_override.css
@@ -1,5 +1,5 @@
 body {
-  background: yellow;
+  background-color: yellow;
 }
 body p {
   color: blue;

--- a/spec/fixtures/assets/stylesheets/_override.css.sass
+++ b/spec/fixtures/assets/stylesheets/_override.css.sass
@@ -1,5 +1,5 @@
 body
-  :background yellow
+  :background-color yellow
   p
     :color green
 

--- a/spec/fixtures/assets/stylesheets/_override.css.scss
+++ b/spec/fixtures/assets/stylesheets/_override.css.scss
@@ -1,5 +1,5 @@
 body {
-  background: yellow;
+  background-color: yellow;
   p {
     color: orange;
   }

--- a/spec/fixtures/assets/stylesheets/foo/_bar_mailer.css.scss
+++ b/spec/fixtures/assets/stylesheets/foo/_bar_mailer.css.scss
@@ -1,0 +1,6 @@
+body {
+  background-color: orange;
+  p {
+    color: purple;
+  }
+}

--- a/spec/fixtures/mailers/foo/bar_mailer.rb
+++ b/spec/fixtures/mailers/foo/bar_mailer.rb
@@ -1,0 +1,11 @@
+require 'rails/all'
+
+module Foo
+  class BarMailer < ActionMailer::Base
+    include InlineStylesMailer
+
+    def bar
+      mail(:to => "test@localhost", :subject => "Test Bar")
+    end
+  end
+end

--- a/spec/fixtures/views/foo/bar_mailer/bar.html.erb
+++ b/spec/fixtures/views/foo/bar_mailer/bar.html.erb
@@ -1,0 +1,1 @@
+<p>Testing foobar html.</p>

--- a/spec/inline_styles_mailer/inline_styles_mailer_spec.rb
+++ b/spec/inline_styles_mailer/inline_styles_mailer_spec.rb
@@ -18,7 +18,7 @@ describe InlineStylesMailer do
         mail = FooMailer.foo
         mail.body.parts.length.should eq(2)
         mail.body.parts[1].body.should =~ /<p style="color: red;">Testing foo text\/html\.<\/p>/
-        mail.body.parts[1].body.should =~ /<body style="background: yellow;">/
+        mail.body.parts[1].body.should =~ /<body style="background-color: yellow;">/
       end
     end
 
@@ -30,7 +30,7 @@ describe InlineStylesMailer do
         mail = FooMailer.foo
         mail.body.parts.length.should eq(2)
         mail.body.parts[1].body.should =~ /<p style="color: orange;">Testing foo text\/html\.<\/p>/
-        mail.body.parts[1].body.should =~ /<body style="background: yellow;">/
+        mail.body.parts[1].body.should =~ /<body style="background-color: yellow;">/
       end
     end
 
@@ -42,7 +42,7 @@ describe InlineStylesMailer do
         mail = FooMailer.foo
         mail.body.parts.length.should eq(2)
         mail.body.parts[1].body.should =~ /<p style="color: green;">Testing foo text\/html\.<\/p>/
-        mail.body.parts[1].body.should =~ /<body style="background: yellow;">/
+        mail.body.parts[1].body.should =~ /<body style="background-color: yellow;">/
       end
     end
 
@@ -54,7 +54,7 @@ describe InlineStylesMailer do
         mail = FooMailer.foo
         mail.body.parts.length.should eq(2)
         mail.body.parts[1].body.should =~ /<p style="color: blue;">Testing foo text\/html\.<\/p>/
-        mail.body.parts[1].body.should =~ /<body style="background: yellow;">/
+        mail.body.parts[1].body.should =~ /<body style="background-color: yellow;">/
       end
     end
 
@@ -80,6 +80,20 @@ describe InlineStylesMailer do
       end
     end
 
+  end
+
+  describe "Namespaced mailers" do
+    context "Default CSS file" do
+      before do
+        Foo::BarMailer.stylesheet_path "assets/stylesheets"
+      end
+
+      it "should inline the CSS" do
+        mail = Foo::BarMailer.bar
+        mail.body.should =~ /<p style="color: purple;">Testing foobar html\.<\/p>/
+        mail.body.should =~ /<body style="background-color: orange;">/
+      end
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'rails/all'
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.prepend_view_path File.join(File.dirname(__FILE__), "fixtures", "views")
 
-Dir["#{File.dirname(__FILE__)}/fixtures/mailers/*.rb"].each { |f| require f }
+Dir["#{File.dirname(__FILE__)}/fixtures/mailers/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|


### PR DESCRIPTION
CSS background property is a shortcut for background-color.
After processing scss background automatically substitute with background-color.
That caused spec to file. Change background to background-color in tests and fixtures.