### PR TITLE
Add support for Rails 5.1 and Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ matrix:
       gemfile: spec/Gemfile.rails-4.2
     - rvm: 2.3.0
       gemfile: spec/Gemfile.rails-5.0
+    - rvm: 2.3.3
+      gemfile: spec/Gemfile.rails-5.1
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ matrix:
       gemfile: spec/Gemfile.rails-5.0
     - rvm: 2.3.3
       gemfile: spec/Gemfile.rails-5.1
+    - rvm: 2.3.3
+      gemfile: spec/Gemfile.rails-5.2
 sudo: false

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ We decided to bump up the major version because of a fix (5d0b6f4) we made to th
 
 ## What versions of Rails does this work with?
 
-We run tests using Rails `4.2.6` and `5.0.0.beta3`.
+We run tests using Rails `4.2.6`, `5.0.0.beta3`, `5.1.6` and `5.2`
 
 | Version | Working? |
 | --- | --- |
@@ -113,7 +113,8 @@ We run tests using Rails `4.2.6` and `5.0.0.beta3`.
 | 4.1 | Yes |
 | 4.2 | Yes |
 | 5.0 | Yes |
-| 5.1 | No ** |
+| 5.1 | Yes |
+| 5.2 | Yes |
 
 \* It relies on the asset pipeline so I'd be surprised if it works. Not tested.
 

--- a/inline_styles_mailer.gemspec
+++ b/inline_styles_mailer.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.add_development_dependency "rspec"
   s.add_runtime_dependency "inline_styles"
-  s.add_runtime_dependency "rails", [">= 3.1", "< 5.1"]
+  s.add_runtime_dependency "rails", [">= 3.1", "< 5.2"]
   s.add_runtime_dependency "sass-rails"
 end

--- a/inline_styles_mailer.gemspec
+++ b/inline_styles_mailer.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.add_development_dependency "rspec"
   s.add_runtime_dependency "inline_styles"
-  s.add_runtime_dependency "rails", [">= 3.1", "< 5.2"]
+  s.add_runtime_dependency "rails", [">= 3.1", "<= 5.2"]
   s.add_runtime_dependency "sass-rails"
 end

--- a/lib/inline_styles_mailer.rb
+++ b/lib/inline_styles_mailer.rb
@@ -85,7 +85,12 @@ module InlineStylesMailer
             case extension
             when :html
               html = render_to_string :file => file, :layout => layout_to_use, handlers: [handler]
-              render :text => self.class.page.with_html(html).apply
+              # Rails 5.1 removed render :text
+              if Gem.loaded_specs['rails'].version >= Gem::Version.create('5.0')
+                render :plain => self.class.page.with_html(html).apply
+              else
+                render :text => self.class.page.with_html(html).apply
+              end
             else
               render
             end

--- a/spec/Gemfile.rails-5.1
+++ b/spec/Gemfile.rails-5.1
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+gem 'inline_styles'
+gem 'rails', '~> 5.1.6'
+gem 'rspec'
+gem 'sass-rails'

--- a/spec/Gemfile.rails-5.2
+++ b/spec/Gemfile.rails-5.2
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+gem 'inline_styles'
+gem 'rails', '~> 5.2'
+gem 'rspec'
+gem 'sass-rails'


### PR DESCRIPTION
Greetings @billhorsman,

We use this wonderful gem at work and while in the middle of an upgrade to Rails 5.1, we needed to relax the dependency to account for allowing Rails 5.1. I was hoping that we could get this merged in so we don't need to use a custom fork. 

Side-note: I debated on moving forward with the premailers gem, but decided in the middle of an upgrade to 5.1 it was important to make as little changes as possible to the gems we use and have worked great so far. 

Thanks once again. 