### PR TITLE
Relax Gemspec runtime dependency for Rails 5.2.1

### DIFF
--- a/inline_styles_mailer.gemspec
+++ b/inline_styles_mailer.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.add_development_dependency "rspec"
   s.add_runtime_dependency "inline_styles"
-  s.add_runtime_dependency "rails", [">= 3.1", "<= 5.2"]
+  s.add_runtime_dependency "rails", [">= 3.1", "<= 6"]
   s.add_runtime_dependency "sass-rails"
 end

--- a/spec/Gemfile.rails-5.2
+++ b/spec/Gemfile.rails-5.2
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 gem 'inline_styles'
-gem 'rails', '~> 5.2'
+gem 'rails', '~> 5.2.1'
 gem 'rspec'
 gem 'sass-rails'


### PR DESCRIPTION
Hi @billhorsman!

Nice to see you again here :) I'm working on trying to do our update to Rails 5.2.1 for my Work and it turns out when I added support for 5.1 and 5.2 I set the gemspec runtime dependency too strong. 

So this PR bumps that for anything less than Rails 6 and then bumps TravisCI's Rails version to 5.2.1 similar to how the Rails 5.1 gemspec calls for 5.1.6.

Once again thanks for taking a look at this!